### PR TITLE
Switch tuple to list for QuadMagicItems

### DIFF
--- a/Gym/environments/quad_magic_items/environment.py
+++ b/Gym/environments/quad_magic_items/environment.py
@@ -84,7 +84,7 @@ In such a formation, items `a`, `b`, `c`, and `d` are called type `A`, `B`, `C`,
         self.parameter["reference_answer"] = ""
         for xi in X:
             A_cnt, B_cnt, C_cnt, D_cnt = ans_val[xi]
-            self.parameter["gold_answer"].append((A_cnt, B_cnt, C_cnt, D_cnt))
+            self.parameter["gold_answer"].append([A_cnt, B_cnt, C_cnt, D_cnt])
             self.parameter["reference_answer"] += "{} {} {} {}\n".format(A_cnt, B_cnt, C_cnt, D_cnt)
     
 
@@ -100,7 +100,7 @@ In such a formation, items `a`, `b`, `c`, and `d` are called type `A`, `B`, `C`,
                 for line in answer.splitlines() :
                     line = line.strip()
                     if line :
-                        matrix.append(tuple(map(int, line.split())))
+                        matrix.append(list(map(int, line.split())))
                         if len(matrix[-1]) != 4 :
                             return None
                 return matrix


### PR DESCRIPTION
Hi again,

Looks like one env slipped through my tests, somehow. I reran some things from scratch, and found that QuadMagicItems was failing due to the same JSON serialization case mentioned in #4. 

I also updated my code to use the verifier's thresholded comparison w.r.t. reference_answer when it exists, and everything seems good in that code path. Manually inspected all the uniformly wrong envs (of which there were only 3) and it was because the model was legitimately wrong.